### PR TITLE
user 탈퇴 시 연관 되어있는 board, board_like 삭제해서 user 탈퇴 오류 해결

### DIFF
--- a/backend/src/main/java/teamproject/backend/domain/BoardLike.java
+++ b/backend/src/main/java/teamproject/backend/domain/BoardLike.java
@@ -21,6 +21,7 @@ public class BoardLike {
     // 좋아요 누른 글
     @ManyToOne(fetch = FetchType.LAZY) // 지연로딩 방식, 실제 board를 사용하는 시점에만 조회하는 쿼리 나감.
     @JoinColumn(name = "board_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Board board;
 
     // 좋아요 누른 유저

--- a/backend/src/main/java/teamproject/backend/domain/User.java
+++ b/backend/src/main/java/teamproject/backend/domain/User.java
@@ -31,7 +31,7 @@ public class User {
     @Column
     private String salt;
 
-    @OneToMany
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
     private List<Board> board_list = new LinkedList<>();
 
     public User(String username, String email, String password, String salt) {


### PR DESCRIPTION
## 요약
user 탈퇴 시 연관 되어있는 board, board_like 삭제해서 user 탈퇴 오류 해결
<br><br>

## 작업 내용
user 탈퇴 시 게시글 작성 한 글이 있으면 삭제 안되는 오류 해결했습니다.
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

<br><br>

## 참고블로그

<br><br>
