### PR TITLE
Tag 버그수정, Board update 추가,boardResponse에 좋아요, 댓글 수 추가

### DIFF
--- a/src/main/java/teamproject/backend/board/BoardController.java
+++ b/src/main/java/teamproject/backend/board/BoardController.java
@@ -42,6 +42,12 @@ public class BoardController {
         return new BaseResponse("성공적으로 글이 작성됐습니다.");
     }
 
+    @PatchMapping("/auth/board/{board_id}")
+    public BaseResponse boardUpdate(@Validated(ValidationSequence.class) @RequestBody BoardWriteRequest boardWriteRequest, @PathVariable Long board_id){
+        boardService.update(board_id, boardWriteRequest);
+        return new BaseResponse("성공적으로 글이 수정됐습니다.");
+    }
+
     /**
      * 카테고리 글 목록 조회
      * [GET] /board/list

--- a/src/main/java/teamproject/backend/board/BoardServiceImpl.java
+++ b/src/main/java/teamproject/backend/board/BoardServiceImpl.java
@@ -135,6 +135,7 @@ public class BoardServiceImpl implements BoardService{
         if(!thumbnailExist(boardWriteRequest.getThumbnail())) throw new BaseException(NOT_EXIST_IMAGE_URL);
 
         board.update(boardWriteRequest, foodCategory);
+        boardTagService.updateBoardTags(board, boardWriteRequest.getTags());
     }
 
     private BoardComment getBoardComment(Long request) {

--- a/src/main/java/teamproject/backend/board/dto/BoardReadResponse.java
+++ b/src/main/java/teamproject/backend/board/dto/BoardReadResponse.java
@@ -19,6 +19,8 @@ public class BoardReadResponse {
     private Date create_date;
     private String thumbnail;
     private String tags;
+    private Integer commented;
+    private Integer liked;
 
     public BoardReadResponse(Board board, String tags){
         this.board_id = board.getBoardId();
@@ -29,5 +31,7 @@ public class BoardReadResponse {
         this.create_date = board.getCreateDate();
         this.thumbnail = board.getThumbnail();
         this.tags = tags;
+        this.commented = board.getCommented();
+        this.liked = board.getLiked();
     }
 }

--- a/src/main/java/teamproject/backend/boardTag/BoardTagService.java
+++ b/src/main/java/teamproject/backend/boardTag/BoardTagService.java
@@ -7,9 +7,10 @@ import java.util.List;
 
 public interface BoardTagService {
     void saveBoardTags(Board board, String tagName);
-    void deleteAllByBoard(Board board);
+    void deleteBoardTags(Board board);
     List<BoardTag> findBoardTagByBoard(Board board);
     String findTagsByBoard(Board board);
     List<BoardTag> findBoardTagByTagName(String tagName);
     List<Board> findBoardByTagName(String tagName);
+    void updateBoardTags(Board board, String tags);
 }

--- a/src/main/java/teamproject/backend/boardTag/BoardTagServiceImpl.java
+++ b/src/main/java/teamproject/backend/boardTag/BoardTagServiceImpl.java
@@ -2,6 +2,7 @@ package teamproject.backend.boardTag;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import teamproject.backend.board.BoardService;
 import teamproject.backend.domain.Board;
 import teamproject.backend.domain.BoardTag;
@@ -54,7 +55,7 @@ public class BoardTagServiceImpl implements BoardTagService{
         return true;
     }
     @Override
-    public void deleteAllByBoard(Board board) {
+    public void deleteBoardTags(Board board) {
         List<BoardTag> boardTags = findBoardTagByBoard(board);
         for(BoardTag boardTag : boardTags){
             boardTagRepository.delete(boardTag);
@@ -92,6 +93,13 @@ public class BoardTagServiceImpl implements BoardTagService{
             boards.add(boardTag.getBoard());
         }
         return boards;
+    }
+
+    @Override
+    @Transactional
+    public void updateBoardTags(Board board, String tags) {
+        deleteBoardTags(board);
+        saveBoardTags(board, tags);
     }
 
 }

--- a/src/main/java/teamproject/backend/boardTag/BoardTagServiceImpl.java
+++ b/src/main/java/teamproject/backend/boardTag/BoardTagServiceImpl.java
@@ -19,8 +19,8 @@ public class BoardTagServiceImpl implements BoardTagService{
     private final TagService tagService;
 
     @Override
-    public void saveBoardTags(Board board, String tagRequest) {
-        List<String> tagNames = splitTagName(tagRequest);
+    public void saveBoardTags(Board board, String tagRequest){
+        List<String> tagNames = splitTagName(tagRequest.replace(" ", ""));
         for(String tagName : tagNames){
             createTag(tagName);
             Tag tag = tagService.findByName(tagName);
@@ -39,7 +39,7 @@ public class BoardTagServiceImpl implements BoardTagService{
         List<String> tagNames = new ArrayList<>();
         for(String tagName : tagArray){
             if(usableTagName(tagName)){
-                tagNames.add(deleteLastChar(tagName));
+                tagNames.add(tagName);
             }
         }
         return tagNames;
@@ -74,7 +74,7 @@ public class BoardTagServiceImpl implements BoardTagService{
         for(BoardTag boardTag : boardTags){
             tags += "#" + boardTag.getTag().getTagName() + " ";
         }
-        return tags;
+        return deleteLastChar(tags);
     }
 
     @Override

--- a/src/main/java/teamproject/backend/domain/BoardTag.java
+++ b/src/main/java/teamproject/backend/domain/BoardTag.java
@@ -21,7 +21,7 @@ public class BoardTag {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Board board;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)//boardTag 조회시 Tag를 반드시 조회하는 구조
     @JoinColumn(name = "tag_id")
     private Tag tag;
 


### PR DESCRIPTION
## 요약
Tag 버그수정, Board update 추가,boardResponse에 좋아요, 댓글 수 추가

<br><br>

## 작업 내용
[BUGFIX : Fix When tag name is stored incorrectly]
1.BoardTagServiceImpl 에서 saveBoardTags 하기 전 공백문자 제거 후 실행.
2.boardTag 조회 시 Tag의 이름 조회가 필수적인 관계로 BoardTag 속 Tag를 즉시로딩으로 변경

[Feat : creat Board Update [PATCH] board/{board_id}]
1. 기존 존재하던 boardService의 update를 사용하여 controller 에 boardUpdate 생성
2. 기존 boardService.update에 태그 업데이트 기능 추가
3. 2을 위해 boardTag에 updateBoardTags 생성
4. saveBoardTags, updateBoardTags의 이름과 통일하기 위해 deleteAllBy -> deleteBoardTags로 변경

[Feat : plus commented & liked in BoardReadRespose]
1. BoardReadResponse에서 좋아요 수(liked), 댓글 수(commented) 추가
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

<br><br>

## 참고블로그

<br><br>
