### PR TITLE
게시글 응답 변경, 좋아요 순 댓글 순 api 경로 변경

### DIFF
--- a/src/main/java/teamproject/backend/board/BoardController.java
+++ b/src/main/java/teamproject/backend/board/BoardController.java
@@ -3,7 +3,7 @@ package teamproject.backend.board;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import teamproject.backend.board.dto.BoardReadResponse;
+import teamproject.backend.board.dto.BoardResponseInDetailFormat;
 import teamproject.backend.board.dto.BoardWriteRequest;
 import teamproject.backend.boardComment.BoardCommentService;
 import teamproject.backend.boardComment.dto.BoardCommentResponse;
@@ -55,8 +55,8 @@ public class BoardController {
      * @return
      */
     @GetMapping("/board/list")
-    public BaseResponse<List<BoardReadResponse>> boardListByCategory(@RequestParam String category){
-        List<BoardReadResponse> pages = boardService.findBoardReadResponseListByFoodCategoryName(category);
+    public BaseResponse<List<BoardResponseInDetailFormat>> boardListByCategory(@RequestParam String category){
+        List<BoardResponseInDetailFormat> pages = boardService.findBoardReadResponseListByFoodCategoryName(category);
         return new BaseResponse<>("성공적으로 글을 가져왔습니다.", pages);
     }
 
@@ -66,8 +66,8 @@ public class BoardController {
      * @return
      */
     @GetMapping("/board/list/{user_id}")
-    public BaseResponse<List<BoardReadResponse>> boardListByUser(@PathVariable Long user_id){
-        List<BoardReadResponse> pages = boardService.findBoardReadResponseListByUserId(user_id);
+    public BaseResponse<List<BoardResponseInDetailFormat>> boardListByUser(@PathVariable Long user_id){
+        List<BoardResponseInDetailFormat> pages = boardService.findBoardReadResponseListByUserId(user_id);
         return new BaseResponse<>("성공적으로 글을 가져왔습니다.", pages);
     }
 
@@ -78,8 +78,8 @@ public class BoardController {
      * @return
      */
     @GetMapping("/board")
-    public BaseResponse<BoardReadResponse> searchBoard(@RequestParam Long board_id){
-        BoardReadResponse boardReadResponse = boardService.findBoardReadResponseByBoardId(board_id);
+    public BaseResponse<BoardResponseInDetailFormat> searchBoard(@RequestParam Long board_id){
+        BoardResponseInDetailFormat boardReadResponse = boardService.findBoardReadResponseByBoardId(board_id);
         return new BaseResponse<>("성공적으로 글을 가져왔습니다.", boardReadResponse);
     }
 
@@ -186,14 +186,14 @@ public class BoardController {
     }
 
     @GetMapping("/board/list/best/liked")
-    public BaseResponse<List<BoardReadResponse>> boardListOrderByLiked(){
-        List<BoardReadResponse> pages = boardService.findBoardReadResponseOrderByLikedDesc(10);
+    public BaseResponse<List<BoardResponseInDetailFormat>> boardListOrderByLiked(){
+        List<BoardResponseInDetailFormat> pages = boardService.findBoardReadResponseOrderByLikedDesc(10);
         return new BaseResponse<>("성공적으로 글을 가져왔습니다.", pages);
     }
 
     @GetMapping("/board/list/best/commented")
-    public BaseResponse<List<BoardReadResponse>> boardListOrderByCommented(){
-        List<BoardReadResponse> pages = boardService.findBoardReadResponseOrderByCommentedDesc(10);
+    public BaseResponse<List<BoardResponseInDetailFormat>> boardListOrderByCommented(){
+        List<BoardResponseInDetailFormat> pages = boardService.findBoardReadResponseOrderByCommentedDesc(10);
         return new BaseResponse<>("성공적으로 글을 가져왔습니다.", pages);
     }
 }

--- a/src/main/java/teamproject/backend/board/BoardController.java
+++ b/src/main/java/teamproject/backend/board/BoardController.java
@@ -56,7 +56,7 @@ public class BoardController {
      */
     @GetMapping("/board/list")
     public BaseResponse<List<BoardResponseInDetailFormat>> boardListByCategory(@RequestParam String category){
-        List<BoardResponseInDetailFormat> pages = boardService.findBoardReadResponseListByFoodCategoryName(category);
+        List<BoardResponseInDetailFormat> pages = boardService.findBoardListByFoodCategoryName(category);
         return new BaseResponse<>("성공적으로 글을 가져왔습니다.", pages);
     }
 
@@ -67,7 +67,7 @@ public class BoardController {
      */
     @GetMapping("/board/list/{user_id}")
     public BaseResponse<List<BoardResponseInDetailFormat>> boardListByUser(@PathVariable Long user_id){
-        List<BoardResponseInDetailFormat> pages = boardService.findBoardReadResponseListByUserId(user_id);
+        List<BoardResponseInDetailFormat> pages = boardService.findBoardListByUserId(user_id);
         return new BaseResponse<>("성공적으로 글을 가져왔습니다.", pages);
     }
 
@@ -79,7 +79,7 @@ public class BoardController {
      */
     @GetMapping("/board")
     public BaseResponse<BoardResponseInDetailFormat> searchBoard(@RequestParam Long board_id){
-        BoardResponseInDetailFormat boardReadResponse = boardService.findBoardReadResponseByBoardId(board_id);
+        BoardResponseInDetailFormat boardReadResponse = boardService.findBoardById(board_id);
         return new BaseResponse<>("성공적으로 글을 가져왔습니다.", boardReadResponse);
     }
 
@@ -185,15 +185,4 @@ public class BoardController {
         return new BaseResponse("성공적으로 대댓글 목록을 조회했습니다.", list);
     }
 
-    @GetMapping("/board/list/best/liked")
-    public BaseResponse<List<BoardResponseInDetailFormat>> boardListOrderByLiked(){
-        List<BoardResponseInDetailFormat> pages = boardService.findBoardReadResponseOrderByLikedDesc(10);
-        return new BaseResponse<>("성공적으로 글을 가져왔습니다.", pages);
-    }
-
-    @GetMapping("/board/list/best/commented")
-    public BaseResponse<List<BoardResponseInDetailFormat>> boardListOrderByCommented(){
-        List<BoardResponseInDetailFormat> pages = boardService.findBoardReadResponseOrderByCommentedDesc(10);
-        return new BaseResponse<>("성공적으로 글을 가져왔습니다.", pages);
-    }
 }

--- a/src/main/java/teamproject/backend/board/BoardService.java
+++ b/src/main/java/teamproject/backend/board/BoardService.java
@@ -1,8 +1,8 @@
 package teamproject.backend.board;
 
+import teamproject.backend.board.dto.BoardResponseInCardFormat;
 import teamproject.backend.board.dto.BoardResponseInDetailFormat;
 import teamproject.backend.board.dto.BoardWriteRequest;
-import teamproject.backend.domain.Board;
 import teamproject.backend.domain.User;
 
 import java.util.List;
@@ -10,17 +10,15 @@ import java.util.List;
 public interface BoardService {
     Long save(BoardWriteRequest boardWriteRequest);
 
-    BoardResponseInDetailFormat findBoardReadResponseByBoardId(Long boardId);
+    BoardResponseInDetailFormat findBoardById(Long boardId);
 
-    Board findBoardByBoardId(Long boardId);
+    List<BoardResponseInDetailFormat> findBoardListByUserId(Long userId);
 
-    List<BoardResponseInDetailFormat> findBoardReadResponseListByUserId(Long userId);
+    List<BoardResponseInDetailFormat> findBoardListByFoodCategoryName(String categoryName);
 
-    List<BoardResponseInDetailFormat> findBoardReadResponseListByFoodCategoryName(String categoryName);
+    List<BoardResponseInCardFormat> findBoardListOrderByCommentedDesc(int numberOfBoard);
 
-    List<BoardResponseInDetailFormat> findBoardReadResponseOrderByCommentedDesc(int numberOfBoard);
-
-    List<BoardResponseInDetailFormat> findBoardReadResponseOrderByLikedDesc(int numberOfBoard);
+    List<BoardResponseInCardFormat> findBoardListOrderByLikedDesc(int numberOfBoard);
 
     void delete(Long userId, Long boardId);
 

--- a/src/main/java/teamproject/backend/board/BoardService.java
+++ b/src/main/java/teamproject/backend/board/BoardService.java
@@ -1,13 +1,7 @@
 package teamproject.backend.board;
 
-import teamproject.backend.board.dto.BoardReadResponse;
+import teamproject.backend.board.dto.BoardResponseInDetailFormat;
 import teamproject.backend.board.dto.BoardWriteRequest;
-import teamproject.backend.boardComment.dto.BoardCommentResponse;
-import teamproject.backend.boardComment.dto.BoardCommentUpdateRequest;
-import teamproject.backend.boardComment.dto.BoardCommentWriteRequest;
-import teamproject.backend.boardCommentReply.dto.BoardCommentReplyResponse;
-import teamproject.backend.boardCommentReply.dto.BoardCommentReplyUpdateRequest;
-import teamproject.backend.boardCommentReply.dto.BoardCommentReplyWriteRequest;
 import teamproject.backend.domain.Board;
 import teamproject.backend.domain.User;
 
@@ -16,17 +10,17 @@ import java.util.List;
 public interface BoardService {
     Long save(BoardWriteRequest boardWriteRequest);
 
-    BoardReadResponse findBoardReadResponseByBoardId(Long boardId);
+    BoardResponseInDetailFormat findBoardReadResponseByBoardId(Long boardId);
 
     Board findBoardByBoardId(Long boardId);
 
-    List<BoardReadResponse> findBoardReadResponseListByUserId(Long userId);
+    List<BoardResponseInDetailFormat> findBoardReadResponseListByUserId(Long userId);
 
-    List<BoardReadResponse> findBoardReadResponseListByFoodCategoryName(String categoryName);
+    List<BoardResponseInDetailFormat> findBoardReadResponseListByFoodCategoryName(String categoryName);
 
-    List<BoardReadResponse> findBoardReadResponseOrderByCommentedDesc(int numberOfBoard);
+    List<BoardResponseInDetailFormat> findBoardReadResponseOrderByCommentedDesc(int numberOfBoard);
 
-    List<BoardReadResponse> findBoardReadResponseOrderByLikedDesc(int numberOfBoard);
+    List<BoardResponseInDetailFormat> findBoardReadResponseOrderByLikedDesc(int numberOfBoard);
 
     void delete(Long userId, Long boardId);
 

--- a/src/main/java/teamproject/backend/board/BoardServiceImpl.java
+++ b/src/main/java/teamproject/backend/board/BoardServiceImpl.java
@@ -3,16 +3,11 @@ package teamproject.backend.board;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import teamproject.backend.board.dto.BoardReadResponse;
+import teamproject.backend.board.dto.BoardResponseInDetailFormat;
 import teamproject.backend.board.dto.BoardWriteRequest;
 import teamproject.backend.boardComment.BoardCommentRepository;
 import teamproject.backend.boardComment.dto.BoardCommentResponse;
-import teamproject.backend.boardComment.dto.BoardCommentUpdateRequest;
-import teamproject.backend.boardComment.dto.BoardCommentWriteRequest;
 import teamproject.backend.boardCommentReply.BoardCommentReplyRepository;
-import teamproject.backend.boardCommentReply.dto.BoardCommentReplyResponse;
-import teamproject.backend.boardCommentReply.dto.BoardCommentReplyUpdateRequest;
-import teamproject.backend.boardCommentReply.dto.BoardCommentReplyWriteRequest;
 import teamproject.backend.boardTag.BoardTagService;
 import teamproject.backend.domain.*;
 import teamproject.backend.foodCategory.FoodCategoryService;
@@ -68,10 +63,10 @@ public class BoardServiceImpl implements BoardService{
     }
 
     @Override
-    public BoardReadResponse findBoardReadResponseByBoardId(Long boardId){
+    public BoardResponseInDetailFormat findBoardReadResponseByBoardId(Long boardId){
         Board board = findBoardByBoardId(boardId);
         String tags = boardTagService.findTagsByBoard(board);
-        return new BoardReadResponse(board, tags);
+        return new BoardResponseInDetailFormat(board, tags);
     }
 
     @Override
@@ -82,43 +77,43 @@ public class BoardServiceImpl implements BoardService{
     }
 
     @Override
-    public List<BoardReadResponse> findBoardReadResponseListByUserId(Long userId) {
+    public List<BoardResponseInDetailFormat> findBoardReadResponseListByUserId(Long userId) {
         List<Board> boards = boardRepository.findByUser_id(userId);
 
-        List<BoardReadResponse> responses = getBoardReadResponses(boards, boards.size());
+        List<BoardResponseInDetailFormat> responses = getBoardReadResponses(boards, boards.size());
 
         return responses;
     }
 
-    private List<BoardReadResponse> getBoardReadResponses(List<Board> boards, int length) {
-        List<BoardReadResponse> responses = new ArrayList<>();
+    private List<BoardResponseInDetailFormat> getBoardReadResponses(List<Board> boards, int length) {
+        List<BoardResponseInDetailFormat> responses = new ArrayList<>();
         int min = Math.min(boards.size(), length);
         for(int i = 0; i < min; i++){
             Board board = boards.get(i);
             String tags = boardTagService.findTagsByBoard(board);
-            responses.add(new BoardReadResponse(board, tags));
+            responses.add(new BoardResponseInDetailFormat(board, tags));
         }
         return responses;
     }
 
     @Override
-    public List<BoardReadResponse> findBoardReadResponseListByFoodCategoryName(String categoryName) {
+    public List<BoardResponseInDetailFormat> findBoardReadResponseListByFoodCategoryName(String categoryName) {
         FoodCategory foodCategory = foodCategoryService.getFoodCategory(categoryName);
         List<Board> boards = boardRepository.findByCategory(foodCategory);
 
-        List<BoardReadResponse> responses = getBoardReadResponses(boards, boards.size());
+        List<BoardResponseInDetailFormat> responses = getBoardReadResponses(boards, boards.size());
 
         return responses;
     }
 
     @Override
-    public List<BoardReadResponse> findBoardReadResponseOrderByCommentedDesc(int numberOfBoard) {
+    public List<BoardResponseInDetailFormat> findBoardReadResponseOrderByCommentedDesc(int numberOfBoard) {
         List<Board> boards = boardRepository.findAllByOrderByCommentedDesc();
         return getBoardReadResponses(boards, 10);
     }
 
     @Override
-    public List<BoardReadResponse> findBoardReadResponseOrderByLikedDesc(int numberOfBoard) {
+    public List<BoardResponseInDetailFormat> findBoardReadResponseOrderByLikedDesc(int numberOfBoard) {
         List<Board> boards = boardRepository.findAllByOrderByLikedDesc();
         return getBoardReadResponses(boards, 10);
     }

--- a/src/main/java/teamproject/backend/board/BoardServiceImpl.java
+++ b/src/main/java/teamproject/backend/board/BoardServiceImpl.java
@@ -3,6 +3,7 @@ package teamproject.backend.board;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import teamproject.backend.board.dto.BoardResponseInCardFormat;
 import teamproject.backend.board.dto.BoardResponseInDetailFormat;
 import teamproject.backend.board.dto.BoardWriteRequest;
 import teamproject.backend.boardComment.BoardCommentRepository;
@@ -63,29 +64,28 @@ public class BoardServiceImpl implements BoardService{
     }
 
     @Override
-    public BoardResponseInDetailFormat findBoardReadResponseByBoardId(Long boardId){
+    public BoardResponseInDetailFormat findBoardById(Long boardId){
         Board board = findBoardByBoardId(boardId);
         String tags = boardTagService.findTagsByBoard(board);
         return new BoardResponseInDetailFormat(board, tags);
     }
 
-    @Override
-    public Board findBoardByBoardId(Long boardId) {
+    private Board findBoardByBoardId(Long boardId) {
         Optional<Board> board = boardRepository.findById(boardId);
         if(board.isEmpty()) throw new BaseException(NOT_EXIST_BOARD);
         return board.get();
     }
 
     @Override
-    public List<BoardResponseInDetailFormat> findBoardReadResponseListByUserId(Long userId) {
+    public List<BoardResponseInDetailFormat> findBoardListByUserId(Long userId) {
         List<Board> boards = boardRepository.findByUser_id(userId);
 
-        List<BoardResponseInDetailFormat> responses = getBoardReadResponses(boards, boards.size());
+        List<BoardResponseInDetailFormat> responses = getBoardResponsesInDetailFormat(boards, boards.size());
 
         return responses;
     }
 
-    private List<BoardResponseInDetailFormat> getBoardReadResponses(List<Board> boards, int length) {
+    private List<BoardResponseInDetailFormat> getBoardResponsesInDetailFormat(List<Board> boards, int length) {
         List<BoardResponseInDetailFormat> responses = new ArrayList<>();
         int min = Math.min(boards.size(), length);
         for(int i = 0; i < min; i++){
@@ -96,26 +96,37 @@ public class BoardServiceImpl implements BoardService{
         return responses;
     }
 
+    private List<BoardResponseInCardFormat> getBoardResponsesInCardFormat(List<Board> boards, int length){
+        List<BoardResponseInCardFormat> responses = new ArrayList<>();
+        int min = Math.min(boards.size(), length);
+        for(int i = 0; i < min; i++){
+            Board board = boards.get(i);
+            String tags = boardTagService.findTagsByBoard(board);
+            responses.add(new BoardResponseInCardFormat(board, tags));
+        }
+        return responses;
+    }
+
     @Override
-    public List<BoardResponseInDetailFormat> findBoardReadResponseListByFoodCategoryName(String categoryName) {
+    public List<BoardResponseInDetailFormat> findBoardListByFoodCategoryName(String categoryName) {
         FoodCategory foodCategory = foodCategoryService.getFoodCategory(categoryName);
         List<Board> boards = boardRepository.findByCategory(foodCategory);
 
-        List<BoardResponseInDetailFormat> responses = getBoardReadResponses(boards, boards.size());
+        List<BoardResponseInDetailFormat> responses = getBoardResponsesInDetailFormat(boards, boards.size());
 
         return responses;
     }
 
     @Override
-    public List<BoardResponseInDetailFormat> findBoardReadResponseOrderByCommentedDesc(int numberOfBoard) {
+    public List<BoardResponseInCardFormat> findBoardListOrderByCommentedDesc(int numberOfBoard) {
         List<Board> boards = boardRepository.findAllByOrderByCommentedDesc();
-        return getBoardReadResponses(boards, 10);
+        return getBoardResponsesInCardFormat(boards, 10);
     }
 
     @Override
-    public List<BoardResponseInDetailFormat> findBoardReadResponseOrderByLikedDesc(int numberOfBoard) {
+    public List<BoardResponseInCardFormat> findBoardListOrderByLikedDesc(int numberOfBoard) {
         List<Board> boards = boardRepository.findAllByOrderByLikedDesc();
-        return getBoardReadResponses(boards, 10);
+        return getBoardResponsesInCardFormat(boards, 10);
     }
 
     @Override

--- a/src/main/java/teamproject/backend/board/dto/BoardResponseInCardFormat.java
+++ b/src/main/java/teamproject/backend/board/dto/BoardResponseInCardFormat.java
@@ -1,0 +1,35 @@
+package teamproject.backend.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import teamproject.backend.domain.Board;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardResponseInCardFormat {
+    private Long board_id;
+    private String category;
+    private String title;
+    private String user_name;
+    private Date create_date;
+    private String thumbnail;
+    private String tags;
+    private Integer commented;
+    private Integer liked;
+
+    public BoardResponseInCardFormat(Board board, String tags) {
+        this.board_id = board.getBoardId();
+        this.category = board.getCategory().getCategoryName();
+        this.title = board.getTitle();
+        this.user_name = board.getUser().getUsername();
+        this.create_date = board.getCreateDate();
+        this.thumbnail = board.getThumbnail();
+        this.tags = tags;
+        this.commented = board.getCommented();
+        this.liked = board.getLiked();
+    }
+}

--- a/src/main/java/teamproject/backend/board/dto/BoardResponseInDetailFormat.java
+++ b/src/main/java/teamproject/backend/board/dto/BoardResponseInDetailFormat.java
@@ -16,6 +16,7 @@ public class BoardResponseInDetailFormat {
     private String title;
     private String text;
     private String user_name;
+    private Long user_id;
     private Date create_date;
     private String thumbnail;
     private String tags;
@@ -28,6 +29,7 @@ public class BoardResponseInDetailFormat {
         this.title = board.getTitle();
         this.text = board.getText();
         this.user_name = board.getUser().getUsername();
+        this.user_id = board.getUser().getId();
         this.create_date = board.getCreateDate();
         this.thumbnail = board.getThumbnail();
         this.tags = tags;

--- a/src/main/java/teamproject/backend/board/dto/BoardResponseInDetailFormat.java
+++ b/src/main/java/teamproject/backend/board/dto/BoardResponseInDetailFormat.java
@@ -10,7 +10,7 @@ import java.util.Date;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class BoardReadResponse {
+public class BoardResponseInDetailFormat {
     private Long board_id;
     private String category;
     private String title;
@@ -22,7 +22,7 @@ public class BoardReadResponse {
     private Integer commented;
     private Integer liked;
 
-    public BoardReadResponse(Board board, String tags){
+    public BoardResponseInDetailFormat(Board board, String tags){
         this.board_id = board.getBoardId();
         this.category = board.getCategory().getCategoryName();
         this.title = board.getTitle();

--- a/src/main/java/teamproject/backend/mainPage/MainPageController.java
+++ b/src/main/java/teamproject/backend/mainPage/MainPageController.java
@@ -64,13 +64,13 @@ public class MainPageController {
         return new BaseResponse("전체 태그 목록을 가져왔습니다.", tags);
     }
 
-    @GetMapping("/board/list/best/liked")
+    @GetMapping("/main/best/liked/list")
     public BaseResponse<List<BoardResponseInCardFormat>> boardListOrderByLiked(){
         List<BoardResponseInCardFormat> pages = boardService.findBoardListOrderByLikedDesc(10);
         return new BaseResponse<>("성공적으로 글을 가져왔습니다.", pages);
     }
 
-    @GetMapping("/board/list/best/commented")
+    @GetMapping("/main/best/commented/list")
     public BaseResponse<List<BoardResponseInCardFormat>> boardListOrderByCommented(){
         List<BoardResponseInCardFormat> pages = boardService.findBoardListOrderByCommentedDesc(10);
         return new BaseResponse<>("성공적으로 글을 가져왔습니다.", pages);

--- a/src/main/java/teamproject/backend/mainPage/MainPageController.java
+++ b/src/main/java/teamproject/backend/mainPage/MainPageController.java
@@ -5,6 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import teamproject.backend.board.BoardService;
+import teamproject.backend.board.dto.BoardResponseInCardFormat;
+import teamproject.backend.board.dto.BoardResponseInDetailFormat;
 import teamproject.backend.domain.Tag;
 import teamproject.backend.mainPage.dto.GetSearchByResponse;
 import teamproject.backend.response.BaseResponse;
@@ -17,6 +20,7 @@ import java.util.List;
 public class MainPageController {
 
     private final MainPageService mainPageService;
+    private final BoardService boardService;
 
 
     /**
@@ -58,5 +62,17 @@ public class MainPageController {
         List<Tag> tags = mainPageService.allTagList();
 
         return new BaseResponse("전체 태그 목록을 가져왔습니다.", tags);
+    }
+
+    @GetMapping("/board/list/best/liked")
+    public BaseResponse<List<BoardResponseInCardFormat>> boardListOrderByLiked(){
+        List<BoardResponseInCardFormat> pages = boardService.findBoardListOrderByLikedDesc(10);
+        return new BaseResponse<>("성공적으로 글을 가져왔습니다.", pages);
+    }
+
+    @GetMapping("/board/list/best/commented")
+    public BaseResponse<List<BoardResponseInCardFormat>> boardListOrderByCommented(){
+        List<BoardResponseInCardFormat> pages = boardService.findBoardListOrderByCommentedDesc(10);
+        return new BaseResponse<>("성공적으로 글을 가져왔습니다.", pages);
     }
 }


### PR DESCRIPTION
## 요약

<br><br>

## 작업 내용

1. 이제 [GET] /board?board_id 가 user_id를 반환합니다. -> 상세 페이지에서 작성자만 수정 삭제가 보이도록 하기 위해 추가
2. API 가 일부 변경되었습니다. 
    1. 좋아요 순 글 목록 가져오기
        1. 기존 : /board/list/best/liked
        2. 변경 : /main/best/liked/list
    2. 댓글 순 글 목록 가져오기
        1. 기존 : /board/list/best/commented
        2. 변경 :  /main/best/commented/list
    3. 좋아요 순, 댓글 순 API의 위치가 Board에서 Main으로 이동했습니다.
3. 이제 좋아요 순, 댓글 많은 수 API가 text를 반환하지 않습니다.

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

<br><br>

## 참고블로그

<br><br>
