### PR TITLE
Daejun

### DIFF
--- a/src/main/java/teamproject/backend/board/BoardController.java
+++ b/src/main/java/teamproject/backend/board/BoardController.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.data.web.SortDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import teamproject.backend.board.dto.*;
@@ -23,7 +22,6 @@ import teamproject.backend.user.UserService;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -188,8 +186,8 @@ public class BoardController {
      * @return
      */
     @GetMapping("/board/all/list")
-    public BaseResponse findBoarListByAll(@SortDefault(sort = "createDate", direction = Sort.Direction.DESC) Sort sort) {
-        List<BoardResponseInCardFormat> boarListByAll = boardService.findBoarListByAll(sort);
+    public BaseResponse findBoarListByAll(@PageableDefault(size = 20, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        BoardListResponseAll boarListByAll = boardService.findBoarListByAll(pageable);
 
         return new BaseResponse("성공적으로 전체 게시글 목록을 조회했습니다.", boarListByAll);
     }

--- a/src/main/java/teamproject/backend/board/BoardController.java
+++ b/src/main/java/teamproject/backend/board/BoardController.java
@@ -60,7 +60,7 @@ public class BoardController {
      * @return
      */
     @GetMapping("/board/list")
-    public BaseResponse boardListByCategory(@PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable, @RequestParam String category){
+    public BaseResponse boardListByCategory(@PageableDefault(size = 20, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable, @RequestParam String category){
         BoardListResponseByCategory pages = boardService.findBoardListByFoodCategoryName(pageable, category);
         return new BaseResponse("성공적으로 글을 가져왔습니다.", pages);
     }

--- a/src/main/java/teamproject/backend/board/BoardRepository.java
+++ b/src/main/java/teamproject/backend/board/BoardRepository.java
@@ -23,6 +23,10 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             "where b.category = :category")
     Page<BoardResponseInCardFormat> findByCategory(Pageable pageable, FoodCategory category);
 
+    @Query("select new teamproject.backend.board.dto.BoardResponseInCardFormat(b.boardId, b.category.categoryName, " +
+            "b.title, b.user.nickname, b.createDate, b.thumbnail, b.commented, b.liked, b.view) " +
+            "from Board b ")
+    Page<BoardResponseInCardFormat> findCardByAll(Pageable pageable);
     List<Board> findByUser(User user);
 
     @Query("select new teamproject.backend.mypage.dto.BoardByUserResponse(b.boardId, b.title, b.commented) from Board b where b.user.id =:userId")

--- a/src/main/java/teamproject/backend/board/BoardService.java
+++ b/src/main/java/teamproject/backend/board/BoardService.java
@@ -1,7 +1,6 @@
 package teamproject.backend.board;
 
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import teamproject.backend.board.dto.*;
 import teamproject.backend.domain.User;
 
@@ -20,7 +19,7 @@ public interface BoardService {
 
     void update(Long boardId, BoardWriteRequest boardWriteRequest);
 
-    List<BoardResponseInCardFormat> findBoarListByAll(Sort sort);
+    BoardListResponseAll findBoarListByAll(Pageable pageable);
 
     public List<BoardResponseInCardFormat> findBoarListByLiked();
 

--- a/src/main/java/teamproject/backend/board/BoardServiceImpl.java
+++ b/src/main/java/teamproject/backend/board/BoardServiceImpl.java
@@ -272,7 +272,7 @@ public class BoardServiceImpl implements BoardService{
     public UserBoardResponseInListFormat findBoardListByUser(Pageable pageable, Long userId){
         User user = getUserById(userId);
         Page<BoardByUserResponse> boards = boardRepository.findBannerByUserId(pageable, userId);
-        return new UserBoardResponseInListFormat(boards.getContent(), user, boards.getTotalElements());
+        return new UserBoardResponseInListFormat(boards.getContent(), user, boards.getTotalPages());
     }
 
     public CheckUserLikeBoard checkLiked(Long userId, Long boardId){

--- a/src/main/java/teamproject/backend/board/BoardServiceImpl.java
+++ b/src/main/java/teamproject/backend/board/BoardServiceImpl.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamproject.backend.board.dto.*;
@@ -240,13 +239,13 @@ public class BoardServiceImpl implements BoardService{
 
     /**
      * 게시글 전체 목록
-     * @param sort
+     * @param
      * @return
      */
-    public List<BoardResponseInCardFormat> findBoarListByAll(Sort sort) {
-        List<Board> boards = boardRepository.findAll(sort);
+    public BoardListResponseAll findBoarListByAll(Pageable pageable) {
+        Page<BoardResponseInCardFormat> boards = boardRepository.findCardByAll(pageable);
 
-        return getBoardResponsesInCardFormat(boards, boards.size());
+        return new BoardListResponseAll(boards.getContent(), boards.getTotalPages());
     }
 
     /**

--- a/src/main/java/teamproject/backend/board/dto/BoardListResponseAll.java
+++ b/src/main/java/teamproject/backend/board/dto/BoardListResponseAll.java
@@ -1,0 +1,14 @@
+package teamproject.backend.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardListResponseAll {
+    List<BoardResponseInCardFormat> boards;
+    int total;
+}

--- a/src/main/java/teamproject/backend/board/dto/UserBoardResponseInListFormat.java
+++ b/src/main/java/teamproject/backend/board/dto/UserBoardResponseInListFormat.java
@@ -15,9 +15,9 @@ public class UserBoardResponseInListFormat {
     private List<BoardByUserResponse> boardList;
     private String username;
     private String userPicture;
-    private Long total;
+    private int total;
 
-    public UserBoardResponseInListFormat(List<BoardByUserResponse> boardList, User user, Long total) {
+    public UserBoardResponseInListFormat(List<BoardByUserResponse> boardList, User user, int total) {
         this.boardList = boardList;
         this.username = user.getNickname();
         this.userPicture = user.getImageURL();

--- a/src/main/java/teamproject/backend/boardTag/BoardTagServiceImpl.java
+++ b/src/main/java/teamproject/backend/boardTag/BoardTagServiceImpl.java
@@ -20,6 +20,7 @@ public class BoardTagServiceImpl implements BoardTagService{
 
     @Override
     public void saveBoardTags(Board board, String tagRequest){
+        if(tagRequest == null) return;
         List<String> tagNames = splitTagName(tagRequest.replace(" ", ""));
         for(String tagName : tagNames){
             createTag(tagName);

--- a/src/main/java/teamproject/backend/mypage/MyPageController.java
+++ b/src/main/java/teamproject/backend/mypage/MyPageController.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.data.web.SortDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -170,8 +169,8 @@ public class MyPageController {
      * @return
      */
     @GetMapping("/auth/user/notification/list/{user_id}")
-    public BaseResponse notificationList(@PathVariable Long user_id, @SortDefault(sort = "createDate", direction = Sort.Direction.DESC) Sort sort) {
-        GetNotificationResponse getNotificationResponse = myPageService.notificationByUser(user_id, sort);
+    public BaseResponse notificationList(@PathVariable Long user_id, @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        GetNotificationResponse getNotificationResponse = myPageService.notificationByUser(user_id, pageable);
 
         return new BaseResponse("알림 목록을 불러왔습니다.", getNotificationResponse);
     }

--- a/src/main/java/teamproject/backend/mypage/MyPageService.java
+++ b/src/main/java/teamproject/backend/mypage/MyPageService.java
@@ -1,7 +1,6 @@
 package teamproject.backend.mypage;
 
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import teamproject.backend.mypage.dto.*;
 
 import javax.servlet.http.HttpServletResponse;
@@ -30,7 +29,7 @@ public interface MyPageService {
 
     public void deleteBoardLikes(DeleteBoardLikesRequest request, Long userId);
 
-    public GetNotificationResponse notificationByUser(Long user_id, Sort sort);
+    public GetNotificationResponse notificationByUser(Long user_id, Pageable pageable);
 
     public List<String> suggestNickname(int size);
 

--- a/src/main/java/teamproject/backend/mypage/MyPageServiceImpl.java
+++ b/src/main/java/teamproject/backend/mypage/MyPageServiceImpl.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamproject.backend.board.BoardRepository;
@@ -229,11 +228,14 @@ public class MyPageServiceImpl implements MyPageService {
      * @return
      */
     @Override
-    public GetNotificationResponse notificationByUser(Long user_id, Sort sort) {
+    public GetNotificationResponse notificationByUser(Long user_id, Pageable pageable) {
         User user = myPageRepository.findById(user_id).orElseThrow(() -> new BaseException(USER_NOT_EXIST));
-        List<NotificationResponse> notificationList = notificationRepository.findByUser(user, sort).stream().map(Notification::toDto).collect(Collectors.toList());
+        Page<Notification> notifications = notificationRepository.findByUser(user, pageable);
 
-        GetNotificationResponse getNotificationResponse = GetNotificationResponse.builder().notificationList(notificationList).build();
+        GetNotificationResponse getNotificationResponse = GetNotificationResponse.builder()
+                .notificationList(notifications.getContent().stream().map(Notification::toDto).collect(Collectors.toList()))
+                .total(notifications.getTotalPages())
+                .build();
 
         return getNotificationResponse;
     }

--- a/src/main/java/teamproject/backend/mypage/dto/GetNotificationResponse.java
+++ b/src/main/java/teamproject/backend/mypage/dto/GetNotificationResponse.java
@@ -9,9 +9,11 @@ import java.util.List;
 public class GetNotificationResponse {
 
     List<NotificationResponse> notificationList;
+    int total;
 
     @Builder
-    public GetNotificationResponse(List<NotificationResponse> notificationList) {
+    public GetNotificationResponse(List<NotificationResponse> notificationList, int total) {
         this.notificationList = notificationList;
+        this.total = total;
     }
 }

--- a/src/main/java/teamproject/backend/notification/NotificationRepository.java
+++ b/src/main/java/teamproject/backend/notification/NotificationRepository.java
@@ -1,16 +1,15 @@
 package teamproject.backend.notification;
 
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import teamproject.backend.domain.Notification;
 import teamproject.backend.domain.User;
 
-import java.util.List;
-
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    List<Notification> findByUser(User user, Sort sort);
+    Page<Notification> findByUser(User user, Pageable pageable);
 
 }


### PR DESCRIPTION
## 요약

<br><br>

## 작업 내용
1. 유저 글 목록 api의 응답 값 total 수정 : 이제 의도한 대로 페이지의 개수를 리턴합니다.
2. 프로젝트 내 리스트 형식의 응답을 모두 페이지네이션 처리하였습니다.(해당 PR에서는 1, 2번을 추가했습니다.)
![스크린샷 2023-04-09 오후 1 43 00](https://user-images.githubusercontent.com/97227920/230765140-a9b3ea5f-263b-4f84-8ed3-32b0b024c004.png)
3. 카테고리 별 글 리스트 불러오기 api의 기본 사이즈를 20으로 늘렸습니다.
4. 글쓰기 시 태그 없이 작성할 경우 리스트에 오류나는 현상 해결 : nullPointException 발생하던 것을 조치하였습니다.
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

<br><br>

## 참고블로그

<br><br>
