### PR TITLE
update : 댓글, 대댓글(시분 응답) 본문(년월일 응답)

### DIFF
--- a/src/main/java/teamproject/backend/board/dto/BoardResponseInDetailFormat.java
+++ b/src/main/java/teamproject/backend/board/dto/BoardResponseInDetailFormat.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import teamproject.backend.domain.Board;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 @Getter
@@ -17,7 +18,7 @@ public class BoardResponseInDetailFormat {
     private String text;
     private String user_name;
     private Long user_id;
-    private Date create_date;
+    private String create_date;
     private Integer commented;
     private Integer liked;
     private Integer view;
@@ -29,9 +30,14 @@ public class BoardResponseInDetailFormat {
         this.text = board.getText();
         this.user_name = board.getUser().getNickname();
         this.user_id = board.getUser().getId();
-        this.create_date = board.getCreateDate();
+        this.create_date = asString(board.getCreateDate());
         this.commented = board.getCommented();
         this.liked = board.getLiked();
         this.view = board.getView();
     }
+    private String asString(Date date){
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd hh:mm");
+        return format.format(date);
+    }
+
 }

--- a/src/main/java/teamproject/backend/boardComment/dto/BoardCommentResponse.java
+++ b/src/main/java/teamproject/backend/boardComment/dto/BoardCommentResponse.java
@@ -40,7 +40,7 @@ public class BoardCommentResponse {
     }
 
     private String asString(Date date){
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd hh:mm");
         return format.format(date);
     }
 }

--- a/src/main/java/teamproject/backend/boardCommentReply/dto/BoardCommentReplyResponse.java
+++ b/src/main/java/teamproject/backend/boardCommentReply/dto/BoardCommentReplyResponse.java
@@ -36,7 +36,7 @@ public class BoardCommentReplyResponse {
     }
 
     private String asString(Date date){
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd hh:mm");
         return format.format(date);
     }
 }


### PR DESCRIPTION
## 요약

<br><br>

## 작업 내용
1. 글 상세 페이지의 생성일 응답을 정상적으로 yyy-mm-dd로 리턴합니다.
2. 댓글, 대댓글의 생성일 응답을 이제 yyyy-mm-dd hh:mm 형식으로 리턴합니다.

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

<br><br>

## 참고블로그

<br><br>
